### PR TITLE
Fix Due support

### DIFF
--- a/Entropy.h
+++ b/Entropy.h
@@ -26,6 +26,7 @@
 #ifdef ARDUINO_SAM_DUE
 #include <sam.h>
 #include <sam3xa/include/component/component_trng.h>
+#include <include/pmc.h>
 #endif
 
 // Teensy required headers


### PR DESCRIPTION
https://github.com/pmjdebruijn/Arduino-Entropy-Library/commit/aadd30945e98a96d171a554ddf7708998da37782 broke support for the Arduino Due by removing the `#include` directive for Arduino.h:
```
E:\arduino\libraries\Arduino-Entropy-Library\Entropy.cpp: In member function 'void EntropyClass::initialize()':

E:\arduino\libraries\Arduino-Entropy-Library\Entropy.cpp:62:32: error: 'pmc_enable_periph_clk' was not declared in this scope

   pmc_enable_periph_clk(ID_TRNG);
```
In the spirit of that commit, I have added the `#include` directive for the specific header file that contains the declaration of `pmc_enable_periph_clk`.